### PR TITLE
Refactor  to be faucet agnostic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,7 +991,7 @@ checksum = "6e5c37193a1db1d8ed868c03ec7b152175f26160a5b740e5e484143877e0adf0"
 
 [[package]]
 name = "devnet-pow"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anchor-lang",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -61,12 +61,15 @@ To mine Devnet SOL:
 
 ```
 # Mine for 0.1 SOL
-$ devnet-pow mine --difficulty 3 --reward 0.1 --target-lamports 100000000 -ud
+$ devnet-pow mine --target-lamports 100000000 -ud
 ```
 
 Sample output:
 
 ```
-Keypair mined! Pubkey: AAAzGVeuWJHoDRbRHC2RhPMeCwsdwJTuw5XUXcPatwZk:
-Recieved 0.1 SOL from faucet: 4nPEb6HomarZyESH78QT4kHueitMxW2t5ZN8aynUTqUwgTSJ8LL2yFDrLTFEahd9sff4sfXJzr2NtRFZq3Bk3qM1
+Minimum difficulty: 3
+Setup complete! Starting mining process...
+
+Keypair mined! Pubkey: AAABCmr8KgfZePwZF8RqtCxnwDwosqD1YGsV15VhPCUy:
+Received 0.05 SOL from faucet AKDUUyPuHjwGqsX865vWKN6nY3SebNu7FsSoYysDzhDJ: 2i6UfWhDu6FZcPqVabQK65hC7tgFoiTdJoub8PsT1kYKZigz7GZkYiER8XUBurqbkD3R7fhZWCoTxDBPp4vhAtCK
 ```

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "devnet-pow"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "A CLI tool for mining devnet SOL"
 license = "MIT"


### PR DESCRIPTION
Enables mining with no parameters required upfront.

For a future change, it might be a good idea to enable scanning for new faucets in a background thread.